### PR TITLE
Add option to get transitive members of groups

### DIFF
--- a/HelperFunctions.psm1
+++ b/HelperFunctions.psm1
@@ -22,18 +22,24 @@ function Get-GraphRequestRecursive {
         [Parameter(Mandatory = $true,
             ValueFromPipeline = $true,
             Position = 1)]
-        [String] $Url
+        [String] $Url,
+
+        # Graph headers
+        [Parameter(Mandatory = $false,
+            Position = 2)]
+        [Hashtable] $AdditionalHeaders = @{}
     )
- 
+
     Write-Debug "Fetching url $Url"
-    $Result = Invoke-RestMethod $Url -Headers @{Authorization = "Bearer $AccessToken" } -Verbose:$false
+    $Headers = @{Authorization = "Bearer $AccessToken" } + $AdditionalHeaders
+    $Result = Invoke-RestMethod $Url -Headers $Headers -Verbose:$false
     if ($Result.value) {
         $Result.value
     }
 
     # Calls itself when there is a nextlink, in order to get next page
     if ($Result.'@odata.nextLink') {
-        Get-GraphRequestRecursive -Url $Result.'@odata.nextLink' -AccessToken $AccessToken
+        Get-GraphRequestRecursive -Url $Result.'@odata.nextLink' -AccessToken $AccessToken -AdditionalHeaders $AdditionalHeaders
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ The following can be useful if you have multple Azure ADs or limitations in scop
 | AADGroupScopingConfig       | 2         | Additional info required to determine groups (filter etc.)  | id eq '<objectid>'                  |
 | GroupDeprovisioningMethod   | Yes       | Determines what to do when source AAD group is deleted      | Delete / ConvertToDistributionGroup / PrintWarning / DoNothing |
 | ADGroupNamePattern          | No        | Format string for AD group name, {0} = displayName from AAD, {1} = objectId from AAD, {2} = mailNickname from AAD | {0} ({1}) |
-| Environment			| No        | Azure Environment (default to AzurePublic)                  | AzureCloud / AzureUSGovernment	    |
+| Environment                 | No        | Azure Environment (default to AzurePublic)                  | AzureCloud / AzureUSGovernment	    |
+| TransitiveMembers           | No        | Retrieves a flat list of members from all child groups of the AAD group | true                    |
 
 1. If AuthenticationMethod is ClientCredentials
 2. If AADGroupScopingMethod is GroupMemberOfGroup or AADGroupScopingConfig


### PR DESCRIPTION
This allows complicated nested groups in AAD to be synced to AD as just a flat list of all users. Handy if you don't want to sync a bunch of intermediate groups.

My use case, I have an ACL group in Azure AD that I want to use with an onprem filesystem:
### AAD
```
ACL_FS_Admin_Files_Modify
└─Role_Business_Admin
│ └─User 1
│ └─User 2
│ └─User 3
│
└─Role_Accounting_Admin
  └─User 2
  └─User 3
  └─User 4
```

Using transitive members of ACL_FS_Admin_Files_Modify, I can sync the group membership so that it the resulting membership in AD is:

### On prem AD
```
ACL_FS_Admin_Files_Modify
└─User 1
└─User 2
└─User 3
└─User 4
```