### PR TITLE
Support PowerShell 7

### DIFF
--- a/Run.ps1
+++ b/Run.ps1
@@ -144,7 +144,7 @@ if($Measure.count -gt 0) {
         Write-Verbose "Starting deletion of groups"
         $ADGroupsForDeletion | ForEach-Object {
             Write-Verbose " - Deleting AD group: $($_.DistinguishedName)"
-            $_ | Remove-ADGroup -Confirm:$false -WhatIf:$WhatIfPreference
+            Remove-ADGroup -Confirm:$false -Identity $_.SID -WhatIf:$WhatIfPreference
         }
     } elseif($Config.GroupDeprovisioningMethod -eq "PrintWarning") {
         Write-Verbose "Print group deletions as warnings"
@@ -155,7 +155,7 @@ if($Measure.count -gt 0) {
         Write-Verbose "Converting AD groups that should be deleted, to distribution groups"
         $ADGroupsForDeletion | ForEach-Object {
             Write-Verbose " - Converting AD group: $($_.DistinguishedName)"
-            $_ | Set-ADGroup -GroupCategory Distribution -WhatIf:$WhatIfPreference
+            Set-ADGroup -GroupCategory Distribution -Identity $_.SID -WhatIf:$WhatIfPreference
         }
     } else {
         Write-Verbose "There are $($ADGroupsForDeletion.count) groups that should be delete. Set GroupDeprovisioningMethod to 'Delete', 'PrintWarning' or 'ConvertToDistributionGroup' in order to enable deprovisioning."


### PR DESCRIPTION
PowerShell 7 loads the ActiveDirectory module in a compatibility session, which results in the output of all commands being deserialized and therefore not suitable to use as pipeline inputs.

e.g.
```
WARNING: Module ActiveDirectory is loaded in Windows PowerShell using WinPSCompatSession remoting session; please note that all input and output of commands from this module will be deserialized objects. 
```

This change uses the `SID` property of the AD group objects as a specific identifier, rather than pipeline input